### PR TITLE
Add bin for creating index files

### DIFF
--- a/bin/reqdir_index
+++ b/bin/reqdir_index
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+/*global require, module*/
+var fs = require( 'fs' );
+var path = require( 'path' );
+var templatePath = __dirname + '/../templates/index.js';
+var targetPath = path.join( process.cwd(), 'index.js' );
+
+function fail( message ){
+    console.error( 'Error: ' + message );
+}
+
+if( !fs.existsSync( targetPath ) ){
+    var reader = fs.createReadStream( templatePath );
+    reader.on( "error", function( err ){
+        fail( 'could not read template file at ' + templatePath );
+    } );
+    reader.on( 'data', function( chunk ){
+        var writer = fs.createWriteStream( targetPath );
+        reader.on('close', function(){
+            writer.end();
+        });
+        writer.on( "error", function( err ){
+            fail( 'could not write index.js file at ' + targetPath );
+        } );
+        writer.on( "close", function(){
+            console.log( 'node-require-dir: index.js file generated at ' + targetPath );
+        } );
+        writer.write(chunk);
+    } )
+}else{
+    fail( 'index.js file already exists at ' + targetPath );
+}

--- a/package.json
+++ b/package.json
@@ -36,5 +36,7 @@
   "scripts": {
     "test": "./node_modules/mocha/bin/mocha"
   },
-  "bin": {}
+  "bin": {
+      "reqdir_index": "./bin/reqdir_index"
+  }
 }

--- a/templates/index.js
+++ b/templates/index.js
@@ -1,0 +1,5 @@
+'use strict';
+var requireDirectory = require('require-directory');
+module.exports = requireDirectory(module);
+
+


### PR DESCRIPTION
Hi there,

I thought it would be handy to have a bin file which allows you to generate a `index.js` into the CWD. The `index.js` being the file that requires the directory it resides in and exports it.

I didn't bother with tests yet, since I first wanted to know what you think. If you like the idea I can add the test, update the readme and squash the commits.
