### PR TITLE
added optional "recurse" param to prevent recursion on subdirectories

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,12 +3,17 @@ var join = require('path').join;
 var resolve = require('path').resolve;
 var dirname = require('path').dirname;
 
-var requireDirectory = module.exports = function(m, path, exclude, callback){
+var requireDirectory = module.exports = function(m, path, exclude, recurse, callback){
   var defaultDelegate = function(path, filename){
     return filename[0] !== '.' && /\.(js|json|coffee)$/i.test(filename);
   };
   var delegate = defaultDelegate;
   var retval = {};
+
+  if(typeof(recurse) === 'function'){
+    callback = recurse;
+    recurse = true;
+  }
 
   // if no path was passed in, assume the equivelant of __dirname from caller
   if(!path){
@@ -36,7 +41,7 @@ var requireDirectory = module.exports = function(m, path, exclude, callback){
   path = resolve(path);
   fs.readdirSync(path).forEach(function(filename){
     var joined = join(path, filename);
-    if(fs.statSync(joined).isDirectory()){
+    if(fs.statSync(joined).isDirectory() && recurse !== false){
       var files = requireDirectory(m, joined, delegate, callback); // this node is a directory; recurse
       if (Object.keys(files).length){
         retval[filename] = files;

--- a/test/test.js
+++ b/test/test.js
@@ -92,5 +92,16 @@ suite('require-directory', function(){
     	//act
     	reqdir(module, path, null, callback);
     });
+
+    test('should take an optional recursion parameter which defaults to true', function(){
+      var test = reqdir(module, PATH_TO_EXAMPLE, null, null);
+      assert.equal('baz!', test.bar.baz);
+    });
+
+    test('should not recurse when the optional recursion param is set to false', function(){
+      var test = reqdir(module, PATH_TO_EXAMPLE, null, false);
+      assert.equal('foo!', test.foo);
+      assert.equal(undefined, test.bar);
+    });
   });
 });


### PR DESCRIPTION
Recursion down directory hierarchies should be the default behavior, but should be preventable if someone only wants the top level directories to be added to the hash. There's not an easy way via the `check` or `callback` params currently, so I added another parameter. Might be cleaner to pull the middle params (path, blacklist, recurse) into an options object at this point, but I didn't go that far.
