### PR TITLE
add argument to convert filenames to camel case. not backward compatible.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,11 @@ var join = require('path').join;
 var resolve = require('path').resolve;
 var dirname = require('path').dirname;
 
-var requireDirectory = module.exports = function(m, path, exclude, callback){
+var toCamel = function(string) {
+  return string.replace(/[-_]([a-z])/g, function (g) { return g[1].toUpperCase(); })
+};
+
+var requireDirectory = module.exports = function(m, path, exclude, camelCase, callback){
   var defaultDelegate = function(path, filename){
     return filename[0] !== '.' && /\.(js|json|coffee)$/i.test(filename);
   };
@@ -37,16 +41,18 @@ var requireDirectory = module.exports = function(m, path, exclude, callback){
   fs.readdirSync(path).forEach(function(filename){
     var joined = join(path, filename);
     if(fs.statSync(joined).isDirectory()){
-      var files = requireDirectory(m, joined, delegate, callback); // this node is a directory; recurse
+      var files = requireDirectory(m, joined, delegate, camelCase, callback); // this node is a directory; recurse
       if (Object.keys(files).length){
-        retval[filename] = files;
+        var key = camelCase ? toCamel(filename) : filename
+        retval[key] = files;
       }
     }else{
       if(joined !== m.filename && delegate(joined, filename)){
         var name = filename.substring(0, filename.lastIndexOf('.')); // hash node shouldn't include file extension
-        retval[name] = m.require(joined);
+        var key = camelCase ? toCamel(name) : name
+        retval[key] = m.require(joined);
         if (callback && typeof(callback) === 'function') {
-          callback(null, retval[name]);
+          callback(null, retval[key]);
         }
       }
     }

--- a/test/example/camel-case/alreadyCamelCase.js
+++ b/test/example/camel-case/alreadyCamelCase.js
@@ -1,0 +1,1 @@
+module.exports = "already camel!";

--- a/test/example/camel-case/snake_case.js
+++ b/test/example/camel-case/snake_case.js
@@ -1,0 +1,1 @@
+module.exports = "snake!";

--- a/test/example/camel-case/spinal-case.js
+++ b/test/example/camel-case/spinal-case.js
@@ -1,0 +1,1 @@
+module.exports = "spinal!";

--- a/test/test.js
+++ b/test/test.js
@@ -79,6 +79,19 @@ suite('require-directory', function(){
       assert.equal(undefined, index.index);
     });
 
+    test('should take an optional camelCase boolean', function() {
+      //arrange
+      var camelCase = true;
+
+      //act
+      var test = reqdir(module, PATH_TO_EXAMPLE, null, true);
+
+      //assert
+      assert.equal('already camel!', test.camelCase.alreadyCamelCase);
+      assert.equal('spinal!', test.camelCase.spinalCase);
+      assert.equal('snake!', test.camelCase.snakeCase);
+    });
+
     test('should take an optional callback', function(done) {
     	//arrange
     	var callback = function(err, mod) {
@@ -90,7 +103,7 @@ suite('require-directory', function(){
     	var path = PATH_TO_EXAMPLE + '/fun';
 
     	//act
-    	reqdir(module, path, null, callback);
+    	reqdir(module, path, null, null, callback);
     });
   });
 });


### PR DESCRIPTION
This is a long shot - it adds an additional argument so it would break backward compatibility, but I think it's quite useful.

The use case is that I name files as spinal case:

```
/routes
  /my-route.js
```

But I want to use them like so:

// app.js

```
var routes = requireDirectory(module, __dirname + '/routes', null, true);
app.get('/my-route', routes.myRoute);
```

Because referring to things like this sucks:

```
app.get('/my-route', routes['my-route']);
```

I like the idea of switching to a config object instead of separate arguments to solve the backward-compatibility issue for future versions.
