### PR TITLE
Make Path parameter relative to __dirname and not the root of the app

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,14 @@ var requireDirectory = module.exports = function(m, path, exclude, callback){
   var delegate = defaultDelegate;
   var retval = {};
 
-  // if no path was passed in, assume the equivelant of __dirname from caller
+  // if no path was passed in, assume the equivelant of __dirname from caller.
+  // otherwise, resolve path relative to the equivelant of __dirname
   if(!path){
     path = dirname(m.filename);
+  }else{
+    console.log(dirname(m.filename))
+    console.log(resolve(dirname(m.filename), path))
+    path = resolve(dirname(m.filename), path);
   }
 
   // if a RegExp was passed in as exclude, create a delegate that blacklists that RegExp

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 var assert = require('assert');
 var reqdir = require('../index');
-var PATH_TO_EXAMPLE = './test/example'; //path is slight weird because of mocha's module scoping
+var PATH_TO_EXAMPLE = './example'; //path is slight weird because of mocha's module scoping
 
 suite('require-directory', function(){
   suite('#', function(){
@@ -91,6 +91,17 @@ suite('require-directory', function(){
 
     	//act
     	reqdir(module, path, null, callback);
+    });
+
+    test('should resolve path relative to __dirname', function(){
+      //act
+      var bar = reqdir(module, './example/bar');
+      var fun = reqdir(module, './example/fun');
+      var funResult = fun.do();
+
+      //assert
+      assert.equal('baz!', bar.baz);
+      assert.equal('gone and done it', funResult);
     });
   });
 });


### PR DESCRIPTION
Currently, the second path parameter is relative to the root of the application, and not relative to the current __dirname. Not sure if the current behaviour is the desired behaviour but I wanted to submit a pull request. 

For example, with a directory structure like the following (where this is located in `/Users/myuser/sites/myapp`):
- /app.js
- /server/routes/index.js
- /server/controllers/index.js

If in `server/routes/index.js` I was to do:

``` js
var controllers = requireDirectory(module, '../controllers')
```

the path would resolve to `/Users/myuser/sites/controllers`. I would have expected it to resolve relative to the directory of the current module (i.e. relative to `path.dirname(m.filename)`) which would have made it `/Users/myuser/sites/myapp/server/controllers`

For now I am doing this to get the desired behaviour:

``` js
var controllers = requireDirectory(module, __dirname + '/../controllers');
```

With this pull request the path is relative to the __dirname and now doing the following resolves to `/Users/myuser/sites/myapp/server/controllers`

``` js
var controllers = requireDirectory(module, '../controllers');
```
