### PR TITLE
Let use file with no extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ var fs = require('fs'),
 function checkFileInclusion(path, filename, options) {
   return (
     // verify file has valid extension
-    (new RegExp('\\.(' + options.extensions.join('|') + ')$', 'i').test(filename)) &&
+    (new RegExp('^(' + options.extensions.join('|') + ')$', 'i').test((filename.match(/\.(.+)/) || ['']).pop())) &&
 
     // if options.include is a RegExp, evaluate it and make sure the path passes
     !(options.include && options.include instanceof RegExp && !options.include.test(path)) &&
@@ -60,7 +60,8 @@ function requireDirectory(m, path, options) {
     var joined = join(path, filename),
       files,
       key,
-      obj;
+      obj,
+      dotId;
 
     if (fs.statSync(joined).isDirectory() && options.recurse) {
       // this node is a directory; recurse
@@ -72,7 +73,8 @@ function requireDirectory(m, path, options) {
     } else {
       if (joined !== m.filename && checkFileInclusion(joined, filename, options)) {
         // hash node key shouldn't include file extension
-        key = filename.substring(0, filename.lastIndexOf('.'));
+        dotId = filename.lastIndexOf('.');
+        key = filename.substring(0, dotId < 0 ? filename.length : dotId);
         obj = m.require(joined);
         retval[options.rename(key, joined, filename)] = options.visit(obj, joined, filename) || obj;
       }

--- a/test/example/noext
+++ b/test/example/noext
@@ -1,0 +1,1 @@
+module.exports = 'noext!';

--- a/test/test.js
+++ b/test/test.js
@@ -28,11 +28,12 @@
 
     test('should be able to specify supported extensions', function () {
       //act
-      var test = reqdir(module, PATH_TO_EXAMPLE, {extensions: ['json']});
+      var test = reqdir(module, PATH_TO_EXAMPLE, {extensions: ['json', '']});
 
       //assert
       assert.equal(undefined, test.foo);
       assert.equal('be', test.bun.should);
+      assert.equal('noext!', test.noext);
     });
 
     test('should be able to exclude path and still pass options', function () {


### PR DESCRIPTION
As this package is used by [yargs](https://github.com/yargs/yargs) in the [`.commandDir()` function](https://github.com/yargs/yargs/blob/master/docs/advanced.md#commanddirdirectory-opts) ([there](https://github.com/yargs/yargs/blob/master/lib/command.js#L109)) , I'd like to be able to require js files with no extension.
Since it doesn't necessarily reflect the file type, I think it would be a good proposal to allow that.